### PR TITLE
install multiple rulesets

### DIFF
--- a/src/modules/engine.js
+++ b/src/modules/engine.js
@@ -56,18 +56,18 @@ module.exports = function(core){
             "url",
             "base",
         ], function(args, ctx, callback){
-            var rids = _.isString(args.rid)
-                ? [args.rid]
-                : (_.isArray(args.rid) ? _.uniq(args.rid) : []);
-
             var install = function(rid, callback){
                 core.installRuleset(args.pico_id, rid, function(err){
                     callback(err, rid);
                 });
             };
 
-            if(!_.isEmpty(rids)){
-                λ.map(rids, install, callback);
+            if(_.isString(args.rid)){
+                install(args.rid, callback);
+                return;
+            }
+            if(_.isArray(args.rid)){
+                λ.map(_.uniq(args.rid), install, callback);
                 return;
             }
             if(_.isString(args.url)){

--- a/src/modules/engine.js
+++ b/src/modules/engine.js
@@ -56,7 +56,7 @@ module.exports = function(core){
                     ? urllib.resolve(opts.base, opts.url)
                     : opts.url;
             }
-            if(!_.isString(pico_id) || (!_.isString(rid) && !_.isString(uri))){
+            if(!_.isString(pico_id) || ( ( !_.isString(rid) && !_.isArray(rid) ) && !_.isString(uri))){
                 return callback(new Error("installRuleset expects, pico_id and rid or url+base"));
             }
 
@@ -65,9 +65,21 @@ module.exports = function(core){
                     callback(err, rid);
                 });
             };
-
+            
+            var doItTwoIt = function(rids){
+                for (var i = rids.length - 1; i >= 0; i--) {
+                    if( !_.isString(rids[i]) ){
+                        return callback(new Error("installRuleset expects every rid in array to be a string."));
+                    }
+                    doIt(rids[i]);
+                }
+            };
+            
             if(_.isString(rid)){
                 return doIt(rid);
+            }
+            if(_.isArray(rid)){
+                return doItTwoIt(rid);
             }
             core.db.findRulesetsByURL(uri, function(err, results){
                 if(err) return callback(err);

--- a/src/modules/engine.test.js
+++ b/src/modules/engine.test.js
@@ -21,16 +21,14 @@ test("engine:getPicoIDByECI", function(t){
     cocb.run(function*(){
         var engine = mockEngine({
             db: {
-                getPicoIDByECI: function(eci, callback){
-                    process.nextTick(function(){
-                        if(eci === "foo"){
-                            return callback(null, "bar");
-                        }else if(eci === "baz"){
-                            return callback(null, "qux");
-                        }
-                        callback("NOT FOUND:" + eci);
-                    });
-                }
+                getPicoIDByECI: tick(function(eci, callback){
+                    if(eci === "foo"){
+                        return callback(null, "bar");
+                    }else if(eci === "baz"){
+                        return callback(null, "qux");
+                    }
+                    callback("NOT FOUND:" + eci);
+                })
             }
         });
         var get = function*(eci){
@@ -54,22 +52,18 @@ test("engine:removeChannel", function(t){
     cocb.run(function*(){
         var engine = mockEngine({
             db: {
-                getPicoIDByECI: function(eci, callback){
-                    process.nextTick(function(){
-                        if(eci === "foo"){
-                            return callback(null, "bar");
-                        }
-                        callback("NOT FOUND:" + eci);
-                    });
-                },
-                removeChannel: function(pico_id, eci, callback){
-                    process.nextTick(function(){
-                        if(pico_id === "bar" && eci === "foo"){
-                            return callback();
-                        }
-                        callback("cannot removeChannel " + pico_id + "," + eci);
-                    });
-                }
+                getPicoIDByECI: tick(function(eci, callback){
+                    if(eci === "foo"){
+                        return callback(null, "bar");
+                    }
+                    callback("NOT FOUND:" + eci);
+                }),
+                removeChannel: tick(function(pico_id, eci, callback){
+                    if(pico_id === "bar" && eci === "foo"){
+                        return callback();
+                    }
+                    callback("cannot removeChannel " + pico_id + "," + eci);
+                })
             }
         });
         var rm = function*(eci){
@@ -91,13 +85,11 @@ test("engine:registerRuleset", function(t){
     cocb.run(function*(){
 
         var engine = mockEngine({
-            registerRulesetURL: function(url, callback){
-                process.nextTick(function(){
-                    callback(null, {
-                        rid: "rid for: " + url
-                    });
+            registerRulesetURL: tick(function(url, callback){
+                callback(null, {
+                    rid: "rid for: " + url
                 });
-            }
+            })
         });
 
         t.equals(yield engine.registerRuleset({}, {
@@ -181,18 +173,16 @@ test("engine:uninstallRuleset", function(t){
         var order = 0;
 
         var engine = mockEngine({
-            uninstallRuleset: function(id, rid, callback){
+            uninstallRuleset: tick(function(id, rid, callback){
                 if(id !== "pico0"){
                     return callback(new Error("invalid pico_id"));
                 }
                 if(!_.isString(rid)){
                     return callback(new Error("invalid rid"));
                 }
-                process.nextTick(function(){
-                    _.set(uninstalled, [id, rid], order++);
-                    callback();
-                });
-            }
+                _.set(uninstalled, [id, rid], order++);
+                callback();
+            })
         });
 
         t.equals(yield engine.uninstallRuleset({}, {

--- a/test-rulesets/engine.js
+++ b/test-rulesets/engine.js
@@ -98,14 +98,20 @@ module.exports = {
             ]]
         }
       },
+      "prelude": function* (ctx) {
+        ctx.scope.set("pico_id", yield (yield ctx.modules.get(ctx, "event", "attr"))(ctx, ["pico_id"]));
+        ctx.scope.set("rid", yield (yield ctx.modules.get(ctx, "event", "attr"))(ctx, ["rid"]));
+        ctx.scope.set("url", yield (yield ctx.modules.get(ctx, "event", "attr"))(ctx, ["url"]));
+        ctx.scope.set("base", yield (yield ctx.modules.get(ctx, "event", "attr"))(ctx, ["base"]));
+      },
       "postlude": {
         "fired": function* (ctx) {
-          yield (yield ctx.modules.get(ctx, "engine", "installRuleset"))(ctx, [{
-              "pico_id": yield (yield ctx.modules.get(ctx, "event", "attr"))(ctx, ["pico_id"]),
-              "rid": yield (yield ctx.modules.get(ctx, "event", "attr"))(ctx, ["rid"]),
-              "url": yield (yield ctx.modules.get(ctx, "event", "attr"))(ctx, ["url"]),
-              "base": yield (yield ctx.modules.get(ctx, "event", "attr"))(ctx, ["base"])
-            }]);
+          yield (yield ctx.modules.get(ctx, "engine", "installRuleset"))(ctx, [
+            ctx.scope.get("pico_id"),
+            ctx.scope.get("rid"),
+            ctx.scope.get("url"),
+            ctx.scope.get("base")
+          ]);
         },
         "notfired": undefined,
         "always": undefined

--- a/test-rulesets/engine.krl
+++ b/test-rulesets/engine.krl
@@ -24,13 +24,14 @@ ruleset io.picolabs.engine {
   }
   rule installRuleset {
     select when engine installRuleset;
+    pre {
+      pico_id = event:attr("pico_id")
+      rid = event:attr("rid")
+      url = event:attr("url")
+      base = event:attr("base")
+    }
     fired {
-      engine:installRuleset({
-        "pico_id": event:attr("pico_id"),
-        "rid": event:attr("rid"),
-        "url": event:attr("url"),
-        "base": event:attr("base")
-      })
+      engine:installRuleset(pico_id, rid, url, base)
     }
   }
 }


### PR DESCRIPTION
This commit extends engine module to handle multiple rulesets to be installed at once. 
Resolves issue #158.